### PR TITLE
Metadata

### DIFF
--- a/example-datasets/dummy-values/example_metadata.json
+++ b/example-datasets/dummy-values/example_metadata.json
@@ -4,7 +4,10 @@
    "metadata":{
       "citymodelIdentifier":"81d4fae1-7dec-11d0-a765-00a0c91e6bf6",
       "datasetTitle":"3D city model of Chibougamau, Canada",
-      "datasetReferenceDate":"2011-01-28",
+      "datasetReferenceDate":{
+         "date":"2011-01-28",
+         "dateType": "publication"
+      },
       "geographicLocation":"Chibougamau, Canada",
       "datasetLanguage":"English",
       "datasetCharacterSet":"UTF-8",
@@ -26,7 +29,10 @@
       "metadataStandardVersion":"ISO 19115:2014(E)",
       "metadataLanguage":"English",
       "metadataCharacterSet":"UTF-8",
-      "metadataDateStamp":"2011-02-28",
+      "metadataDateStamp":{
+         "date":"2011-02-28",
+         "dateType": "lastRevision"
+      },
       "metadataPointOfContact":{
          "contactName":"3D Geoinformation Group",
          "phone":"+31-6666666666",
@@ -126,6 +132,28 @@
       ],
       "textures":"present",
       "materials":"present",
+      "templates":"present",
+      "geometry-templates":"present",
+      "transform":"present",
+      "extensions":"present",
+      "extensionsMetadata":[{
+         "extensionName":"Linear Cell Complex",
+         "metadata":{
+            "version":"0.2",
+            "url":"https://github.com/tudelft3d/cityjson-lcc-extension/blob/master/linearcellcomplex.json",
+            "status":"maintained",
+            "authority":{
+               "contactName":"3D Geoinformation Group",
+               "phone":"+31-6666666666",
+               "address":"Delft University of Technology, the Netherlands",
+               "emailAddress":"3d.bk@tudelft.nl",
+               "contactType":"organization",
+               "website":"https://3d.bk.tudelft.nl"
+            },
+            "summary":"An extension that allows topological information of a city model to be stored as a Combinatorial Map based Linear Cell Complex",
+            "documentation":"https://www.mdpi.com/2220-9964/8/8/347"
+         }
+      }],
       "presentLoDs":{
          "1.0":1,
          "2.0":3,
@@ -244,32 +272,8 @@
             "TunnelInstallations":2
          },
          "CityObjectGroup":{
-            "uniqueFeatureCount":45,
-            "aggregateFeatureCount":55,
-            "presentLoDs":{
-               "1.0":40,
-               "2.0":15
-            },
-            "Tunnel":{
-            "uniqueFeatureCount":5,
-            "aggregateFeatureCount":5,
-            "presentLoDs":{
-               "2.0":5
-            },
-            "TunnelParts":4,
-            "TunnelIstallations":2
-           },
-           "Bridge":{
-            "uniqueFeatureCount":40,
-            "aggregateFeatureCount":50,
-            "presentLoDs":{
-               "1.0":40,
-               "2.0":10
-            },
-            "BridgeParts":5,
-            "BridgeInstallations":3,
-            "BridgeConstructionElements":2
-           }
+            "presence":"present",
+            "count":4
          }
       }
    },

--- a/example-datasets/dummy-values/example_metadata.json
+++ b/example-datasets/dummy-values/example_metadata.json
@@ -1,12 +1,12 @@
 {
    "type":"CityJSON",
-   "version": "1.0",
+   "version":"1.0",
    "metadata":{
       "citymodelIdentifier":"81d4fae1-7dec-11d0-a765-00a0c91e6bf6",
       "datasetTitle":"3D city model of Chibougamau, Canada",
       "datasetReferenceDate":{
          "date":"2011-01-28",
-         "dateType": "publication"
+         "dateType":"publication"
       },
       "geographicLocation":"Chibougamau, Canada",
       "datasetLanguage":"English",
@@ -31,7 +31,7 @@
       "metadataCharacterSet":"UTF-8",
       "metadataDateStamp":{
          "date":"2011-02-28",
-         "dateType": "lastRevision"
+         "dateType":"lastRevision"
       },
       "metadataPointOfContact":{
          "contactName":"3D Geoinformation Group",
@@ -46,16 +46,18 @@
             "featureIDs":[
                "myterrain01"
             ],
-            "source":[{
-               "description":"Source of some Terrain data",
-               "sourceSpatialResolution":"10 points/m2",
-               "sourceReferenceSystem":"urn:ogc:def:crs:EPSG::4326"
-            },
-            {
-               "description":"Source of other Terrain data",
-               "sourceSpatialResolution":"10 points/m2",
-               "sourceReferenceSystem":"urn:ogc:def:crs:EPSG::4326"
-            }],
+            "source":[
+               {
+                  "description":"Source of some Terrain data",
+                  "sourceSpatialResolution":"10 points/m2",
+                  "sourceReferenceSystem":"urn:ogc:def:crs:EPSG::4326"
+               },
+               {
+                  "description":"Source of other Terrain data",
+                  "sourceSpatialResolution":"10 points/m2",
+                  "sourceReferenceSystem":"urn:ogc:def:crs:EPSG::4326"
+               }
+            ],
             "processStep":{
                "description":"Processing of Terrain data using 3dfier",
                "processor":{
@@ -73,11 +75,13 @@
                "Building",
                "Road"
             ],
-            "source":[{
-               "description":"Source of all Building and Road data",
-               "sourceSpatialResolution":"10 points/m2",
-               "sourceReferenceSystem":"urn:ogc:def:crs:EPSG::4326"
-            }],
+            "source":[
+               {
+                  "description":"Source of all Building and Road data",
+                  "sourceSpatialResolution":"10 points/m2",
+                  "sourceReferenceSystem":"urn:ogc:def:crs:EPSG::4326"
+               }
+            ],
             "processStep":{
                "description":"Generated Building and Road data by extruding from 2D shapefile",
                "processor":{
@@ -130,30 +134,45 @@
          "Tunnel",
          "CityObjectGroup"
       ],
-      "textures":"present",
-      "materials":"present",
+      "appearance":{
+         "textures":"present",
+         "materials":"present",
+         "vertices-texture":"present",
+         "themes-texture":[
+            "theme-t-one",
+            "theme-t-two"
+         ],
+         "themes-material":[
+            "theme-m-one",
+            "theme-m-two"
+         ],
+         "default-theme-texture":"absent",
+         "default-theme-material":"absent"
+      },
       "templates":"present",
       "geometry-templates":"present",
       "transform":"present",
       "extensions":"present",
-      "extensionsMetadata":[{
-         "extensionName":"Linear Cell Complex",
-         "metadata":{
-            "version":"0.2",
-            "url":"https://github.com/tudelft3d/cityjson-lcc-extension/blob/master/linearcellcomplex.json",
-            "status":"maintained",
-            "authority":{
-               "contactName":"3D Geoinformation Group",
-               "phone":"+31-6666666666",
-               "address":"Delft University of Technology, the Netherlands",
-               "emailAddress":"3d.bk@tudelft.nl",
-               "contactType":"organization",
-               "website":"https://3d.bk.tudelft.nl"
-            },
-            "summary":"An extension that allows topological information of a city model to be stored as a Combinatorial Map based Linear Cell Complex",
-            "documentation":"https://www.mdpi.com/2220-9964/8/8/347"
+      "extensionsMetadata":[
+         {
+            "extensionName":"Linear Cell Complex",
+            "metadata":{
+               "version":"0.2",
+               "url":"https://github.com/tudelft3d/cityjson-lcc-extension/blob/master/linearcellcomplex.json",
+               "status":"maintained",
+               "authority":{
+                  "contactName":"3D Geoinformation Group",
+                  "phone":"+31-6666666666",
+                  "address":"Delft University of Technology, the Netherlands",
+                  "emailAddress":"3d.bk@tudelft.nl",
+                  "contactType":"organization",
+                  "website":"https://3d.bk.tudelft.nl"
+               },
+               "summary":"An extension that allows topological information of a city model to be stored as a Combinatorial Map based Linear Cell Complex",
+               "documentation":"https://www.mdpi.com/2220-9964/8/8/347"
+            }
          }
-      }],
+      ],
       "presentLoDs":{
          "1.0":1,
          "2.0":3,

--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -4,9 +4,9 @@
    "definitions":{
       "presentLoDs":{
          "type":"object",
-         "patternProperties": {
-            "^[0-9](\\.[0-9])?$": {
-               "type": "integer"
+         "patternProperties":{
+            "^[0-9](\\.[0-9])?$":{
+               "type":"integer"
             }
          },
          "additionalProperties":false
@@ -49,27 +49,27 @@
          }
       },
       "thematicModels":{
-        "type":"array",
-        "items":{
-          "type":"string",
-          "enum":[
-                  "Building",
-                  "Road",
-                  "Railway",
-                  "TransportSquare",
-                  "TINRelief",
-                  "WaterBody",
-                  "PlantCover",
-                  "SolitaryVegetationObject",
-                  "LandUse",
-                  "CityFurniture",
-                  "GenericCityObject",
-                  "Bridge",
-                  "Tunnel",
-                  "CityObjectGroup"
-                  ]
-              }
-          },
+         "type":"array",
+         "items":{
+            "type":"string",
+            "enum":[
+               "Building",
+               "Road",
+               "Railway",
+               "TransportSquare",
+               "TINRelief",
+               "WaterBody",
+               "PlantCover",
+               "SolitaryVegetationObject",
+               "LandUse",
+               "CityFurniture",
+               "GenericCityObject",
+               "Bridge",
+               "Tunnel",
+               "CityObjectGroup"
+            ]
+         }
+      },
       "contactDetails":{
          "type":"object",
          "properties":{
@@ -272,10 +272,14 @@
          "lineage":{
             "type":"array",
             "items":{
-              "type":"object",
+               "type":"object",
                "properties":{
-                  "statement": {"type": "string"},
-                  "scope": {"type": "string"},
+                  "statement":{
+                     "type":"string"
+                  },
+                  "scope":{
+                     "type":"string"
+                  },
                   "additionalDocumentation":{
                      "type":"string",
                      "format":"uri",
@@ -291,36 +295,46 @@
                      "$ref":"#/definitions/thematicModels"
                   },
                   "source":{
-                    "type": "array",
-                      "items":{
-                        "type": "object",
-                          "properties": {
-                            "description": {"type": "string"},
-                            "sourceSpatialResolution":{"type": "string"},
-                            "sourceReferenceSystem":{
-                               "type":"string",
-                               "pattern":"^urn:ogc:def:crs:EPSG::[0-9]{4,5}$"
-                              },
-                             "sourceCitation":{
-                               "type":"string",
-                                "format":"uri",
-                                "pattern":"^(https?|ftp)://"
-                               },
-                              "sourceMetadata":{
-                                "type":"string",
-                                "format":"uri",
-                                "pattern":"^(https?|ftp)://"
-                               },
-                                "scope":{"type": "string"}
+                     "type":"array",
+                     "items":{
+                        "type":"object",
+                        "properties":{
+                           "description":{
+                              "type":"string"
                            },
-                           "additionalProperties":false
-                       }
-                     },
+                           "sourceSpatialResolution":{
+                              "type":"string"
+                           },
+                           "sourceReferenceSystem":{
+                              "type":"string",
+                              "pattern":"^urn:ogc:def:crs:EPSG::[0-9]{4,5}$"
+                           },
+                           "sourceCitation":{
+                              "type":"string",
+                              "format":"uri",
+                              "pattern":"^(https?|ftp)://"
+                           },
+                           "sourceMetadata":{
+                              "type":"string",
+                              "format":"uri",
+                              "pattern":"^(https?|ftp)://"
+                           },
+                           "scope":{
+                              "type":"string"
+                           }
+                        },
+                        "additionalProperties":false
+                     }
+                  },
                   "processStep":{
-                    "type":"object",
-                    "properties":{
-                        "description":{"type": "string"} ,
-                        "rationale":{"type": "string"} ,
+                     "type":"object",
+                     "properties":{
+                        "description":{
+                           "type":"string"
+                        },
+                        "rationale":{
+                           "type":"string"
+                        },
                         "stepDateTime":{
                            "type":"string",
                            "format":"date-time"
@@ -333,228 +347,264 @@
                            "format":"uri",
                            "pattern":"^(https?|ftp)://"
                         },
-                        "scope": {"type": "string"}
+                        "scope":{
+                           "type":"string"
+                        }
                      },
                      "additionalProperties":false
                   }
-                }
-             } 
-          },
-         "geographicalExtent":{
-               "type":"array",
-               "items":{
-                  "type":"number"
-               },
-               "minItems":6,
-               "maxItems":6
-            },
-            "temporalExtent":{
-               "type":"object",
-               "properties":{
-                  "startDate":{
-                     "type":"string",
-                     "format":"date-time"
-                  },
-                  "endDate":{
-                     "type":"string",
-                     "format":"date-time"
-                  }
                }
+            }
+         },
+         "geographicalExtent":{
+            "type":"array",
+            "items":{
+               "type":"number"
             },
-            "abstract":{
+            "minItems":6,
+            "maxItems":6
+         },
+         "temporalExtent":{
+            "type":"object",
+            "properties":{
+               "startDate":{
+                  "type":"string",
+                  "format":"date-time"
+               },
+               "endDate":{
+                  "type":"string",
+                  "format":"date-time"
+               }
+            }
+         },
+         "abstract":{
+            "type":"string"
+         },
+         "specificUsage":{
+            "type":"string"
+         },
+         "keywords":{
+            "type":"array",
+            "items":{
                "type":"string"
-            },
-            "specificUsage":{
-               "type":"string"
-            },
-            "keywords":{
-               "type":"array",
-               "items":{
+            }
+         },
+         "constraints":{
+            "type":"object",
+            "properties":{
+               "legalConstraints":{
+                  "type":"string",
+                  "enum":[
+                     "copyright",
+                     "patent",
+                     "patentPending",
+                     "trademark",
+                     "licence",
+                     "intellectualPropertyRights",
+                     "restricted",
+                     "otherRestrictions",
+                     "unrestricted",
+                     "licenseUnrestricted",
+                     "licenseEndUser",
+                     "licenseDistributor",
+                     "private",
+                     "statutory",
+                     "confidential",
+                     "sensitiveButUnclassified",
+                     "in-confidence"
+                  ]
+               },
+               "securityConstraints":{
+                  "type":"string",
+                  "enum":[
+                     "unclassified",
+                     "restricted",
+                     "confidential",
+                     "secret",
+                     "topSecret",
+                     "sensitiveButUnclassified",
+                     "forOfficialUseOnly",
+                     "protected",
+                     "limitedDistribution"
+                  ]
+               },
+               "userNote":{
                   "type":"string"
                }
-            },
-            "constraints":{
-               "type":"object",
-               "properties":{
-                  "legalConstraints":{
-                     "type":"string",
-                     "enum":[
-                        "copyright",
-                        "patent",
-                        "patentPending",
-                        "trademark",
-                        "licence",
-                        "intellectualPropertyRights",
-                        "restricted",
-                        "otherRestrictions",
-                        "unrestricted",
-                        "licenseUnrestricted",
-                        "licenseEndUser",
-                        "licenseDistributor",
-                        "private",
-                        "statutory",
-                        "confidential",
-                        "sensitiveButUnclassified",
-                        "in-confidence"
-                     ]
-                  },
-                  "securityConstraints":{
-                     "type":"string",
-                     "enum":[
-                        "unclassified",
-                        "restricted",
-                        "confidential",
-                        "secret",
-                        "topSecret",
-                        "sensitiveButUnclassified",
-                        "forOfficialUseOnly",
-                        "protected",
-                        "limitedDistribution"
-                     ]
-                  },
-                  "userNote":{
+            }
+         },
+         "thematicModels":{
+            "$ref":"#/definitions/thematicModels"
+         },
+         "appearance":{
+            "type":"object",
+            "properties":{
+               "textures":{
+                  "$ref":"#/definitions/presence"
+               },
+               "materials":{
+                  "$ref":"#/definitions/presence"
+               },
+               "vertices-texture":{
+                  "$ref":"#/definitions/presence"
+               },
+               "themes-texture":{
+                  "type":"array",
+                  "items":{
                      "type":"string"
                   }
-               }
-            },
-            "thematicModels":{
-               "$ref":"#/definitions/thematicModels"
-            },
-            "textures":{
-               "$ref":"#/definitions/presence"
-            },
-            "materials":{
-               "$ref":"#/definitions/presence"
-            },
-            "templates":{
-               "$ref":"#/definitions/presence"
-            },
-            "geometry-templates":{
-               "$ref":"#/definitions/presence"
-            },
-            "transform":{
-               "$ref":"#/definitions/presence"
-            },
-            "extensions":{
-               "$ref":"#/definitions/presence"
-            },
-            "extensionsMetadata":{
-               "type":"array",
-               "items":{
-                  "type":"object",
-                   "properties":{
-                      "extensionName": {"type": "string"},
-                      "metadata":{
-                        "type":"object",
-                        "properties":{
-                            "version":{"type": "string"},
-                            "url":{
-                              "type":"string",
-                              "format":"uri",
-                              "pattern":"^(https?|ftp)://"
-                           },
-                            "status":{"type": "string"},
-                            "authority":{
-                               "$ref":"#/definitions/contactDetails"
-                            },
-                            "summary": {"type": "string"},
-                            "documentation":{
-                              "type":"string",
-                              "format":"uri",
-                              "pattern":"^(https?|ftp)://"
-                           }
-                        },
-                        "additionalProperties":false
-                     }
+               },
+               "themes-material":{
+                  "type":"array",
+                  "items":{
+                     "type":"string"
                   }
-               } 
-            },
-            "presentLoDs":{
-               "$ref":"#/definitions/presentLoDs"
-            },
-            "cityfeatureMetadata":{
+               },
+               "default-theme-texture":{
+                  "$ref":"#/definitions/presence"
+               },
+               "default-theme-material":{
+                  "$ref":"#/definitions/presence"
+               }
+            }
+         },
+         "templates":{
+            "$ref":"#/definitions/presence"
+         },
+         "geometry-templates":{
+            "$ref":"#/definitions/presence"
+         },
+         "transform":{
+            "$ref":"#/definitions/presence"
+         },
+         "extensions":{
+            "$ref":"#/definitions/presence"
+         },
+         "extensionsMetadata":{
+            "type":"array",
+            "items":{
                "type":"object",
                "properties":{
-                  "Building":{
-                     "$ref":"#/definitions/featureData",
-                     "BuildingParts":{
-                        "type":"integer"
-                     },
-                     "BuildingInstallations":{
-                        "type":"integer"
-                     }
+                  "extensionName":{
+                     "type":"string"
                   },
-                  "Bridge":{
-                     "$ref":"#/definitions/featureData",
-                     "BridgeParts":{
-                        "type":"integer"
-                     },
-                     "BridgeInstallations":{
-                        "type":"integer"
-                     },
-                     "BridgeConstructionElements":{
-                        "type":"integer"
-                     }
-                  },
-                  "Tunnel":{
-                     "$ref":"#/definitions/featureData",
-                     "TunnelParts":{
-                        "type":"number"
-                     },
-                     "TunnelInstallations":{
-                        "type":"integer"
-                     }
-                  },
-                  "TINRelief":{
-                     "$ref":"#/definitions/featureData",
-                     "triangleCount":{
-                        "type":"integer"
-                     }
-                  },
-                  "Road":{
-                     "$ref":"#/definitions/featureData"
-                  },
-                  "Railway":{
-                     "$ref":"#/definitions/featureData"
-                  },
-                  "TransportSquare":{
-                     "$ref":"#/definitions/featureData"
-                  },
-                  "WaterBody":{
-                     "$ref":"#/definitions/featureData"
-                  },
-                  "PlantCover":{
-                     "$ref":"#/definitions/featureData"
-                  },
-                  "SolitaryVegetationObject":{
-                     "$ref":"#/definitions/featureData"
-                  },
-                  "LandUse":{
-                     "$ref":"#/definitions/featureData"
-                  },
-                  "CityFurniture":{
-                     "$ref":"#/definitions/featureData"
-                  },
-                  "GenericCityObject":{
-                     "$ref":"#/definitions/featureData"
-                  },
-                   "CityObjectGroup":{
+                  "metadata":{
                      "type":"object",
                      "properties":{
-                        "presence":{
-                           "$ref":"#/definitions/presence"
+                        "version":{
+                           "type":"string"
                         },
-                        "count":{
-                           "type":"integer"
+                        "url":{
+                           "type":"string",
+                           "format":"uri",
+                           "pattern":"^(https?|ftp)://"
+                        },
+                        "status":{
+                           "type":"string"
+                        },
+                        "authority":{
+                           "$ref":"#/definitions/contactDetails"
+                        },
+                        "summary":{
+                           "type":"string"
+                        },
+                        "documentation":{
+                           "type":"string",
+                           "format":"uri",
+                           "pattern":"^(https?|ftp)://"
                         }
                      },
-                      "additionalProperties":false
+                     "additionalProperties":false
                   }
-                },
-               "additionalProperties" : false
+               }
             }
-        },
-        "additionalProperties":false
+         },
+         "presentLoDs":{
+            "$ref":"#/definitions/presentLoDs"
+         },
+         "cityfeatureMetadata":{
+            "type":"object",
+            "properties":{
+               "Building":{
+                  "$ref":"#/definitions/featureData",
+                  "BuildingParts":{
+                     "type":"integer"
+                  },
+                  "BuildingInstallations":{
+                     "type":"integer"
+                  }
+               },
+               "Bridge":{
+                  "$ref":"#/definitions/featureData",
+                  "BridgeParts":{
+                     "type":"integer"
+                  },
+                  "BridgeInstallations":{
+                     "type":"integer"
+                  },
+                  "BridgeConstructionElements":{
+                     "type":"integer"
+                  }
+               },
+               "Tunnel":{
+                  "$ref":"#/definitions/featureData",
+                  "TunnelParts":{
+                     "type":"number"
+                  },
+                  "TunnelInstallations":{
+                     "type":"integer"
+                  }
+               },
+               "TINRelief":{
+                  "$ref":"#/definitions/featureData",
+                  "triangleCount":{
+                     "type":"integer"
+                  }
+               },
+               "Road":{
+                  "$ref":"#/definitions/featureData"
+               },
+               "Railway":{
+                  "$ref":"#/definitions/featureData"
+               },
+               "TransportSquare":{
+                  "$ref":"#/definitions/featureData"
+               },
+               "WaterBody":{
+                  "$ref":"#/definitions/featureData"
+               },
+               "PlantCover":{
+                  "$ref":"#/definitions/featureData"
+               },
+               "SolitaryVegetationObject":{
+                  "$ref":"#/definitions/featureData"
+               },
+               "LandUse":{
+                  "$ref":"#/definitions/featureData"
+               },
+               "CityFurniture":{
+                  "$ref":"#/definitions/featureData"
+               },
+               "GenericCityObject":{
+                  "$ref":"#/definitions/featureData"
+               },
+               "CityObjectGroup":{
+                  "type":"object",
+                  "properties":{
+                     "presence":{
+                        "$ref":"#/definitions/presence"
+                     },
+                     "count":{
+                        "type":"integer"
+                     }
+                  },
+                  "additionalProperties":false
+               }
+            },
+            "additionalProperties":false
+         }
       },
       "additionalProperties":false
+   },
+   "additionalProperties":false
 }

--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -267,7 +267,7 @@
             "$ref":"#/definitions/dates"
          },
          "metadataPointOfContact":{
-            "$ref":"#/definitions/contactDetail"
+            "$ref":"#/definitions/contactDetails"
          },
          "lineage":{
             "type":"array",
@@ -448,7 +448,7 @@
                         "type":"object",
                         "properties":{
                             "version":{"type": "string"},
-                            "uri":{
+                            "url":{
                               "type":"string",
                               "format":"uri",
                               "pattern":"^(https?|ftp)://"
@@ -538,7 +538,7 @@
                   "GenericCityObject":{
                      "$ref":"#/definitions/featureData"
                   },
-                   "CityObjectGroups":{
+                   "CityObjectGroup":{
                      "type":"object",
                      "properties":{
                         "presence":{

--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -55,6 +55,43 @@
             }
          }
       },
+      "presence":{
+         "type":"string",
+         "enum":[
+            "present",
+            "absent"
+         ]
+      },
+      "dates":{
+         "type":"object",
+         "properties":{
+            "date":{
+               "type":"string",
+               "format":"date"
+            },
+            "dateType":{
+               "type":"string",
+               "enum":[
+                  "creation",
+                  "publication",
+                  "revision",
+                  "expiry",
+                  "lastUpdate",
+                  "lastRevision",
+                  "nextUpdate",
+                  "unavailable",
+                  "inForce",
+                  "adopted",
+                  "deprecated",
+                  "superseded",
+                  "ValidityBegins",
+                  "validityExpires",
+                  "released",
+                  "distribution"
+               ]
+            }
+         }
+      },
       "thematicModels":{
         "type":"array",
         "items":{
@@ -185,8 +222,7 @@
             "type":"string"
          },
          "datasetReferenceDate":{
-            "type":"string",
-            "format":"date"
+            "$ref":"#/definitions/dates"
          },
          "geographicLocation":{
             "type":"string",
@@ -272,11 +308,10 @@
             "type":"string"
          },
          "metadataDateStamp":{
-            "type":"string",
-            "format":"date"
+            "$ref":"#/definitions/dates"
          },
          "metadataPointOfContact":{
-            "$ref":"#/definitions/contactDetails"
+            "$ref":"#/definitions/contactDetail"
          },
          "lineage":{
             "type":"array",
@@ -430,18 +465,53 @@
                "$ref":"#/definitions/thematicModels"
             },
             "textures":{
-               "type":"string",
-               "enum":[
-                  "present",
-                  "absent"
-               ]
+               "$ref":"#/definitions/presence"
             },
             "materials":{
-               "type":"string",
-               "enum":[
-                  "present",
-                  "absent"
-               ]
+               "$ref":"#/definitions/presence"
+            },
+            "templates":{
+               "$ref":"#/definitions/presence"
+            },
+            "geometry-templates":{
+               "$ref":"#/definitions/presence"
+            },
+            "transform":{
+               "$ref":"#/definitions/presence"
+            },
+            "extensions":{
+               "$ref":"#/definitions/presence"
+            },
+            "extensionsMetadata":{
+               "type":"array",
+               "items":{
+                  "type":"object",
+                   "properties":{
+                      "extensionName": {"type": "string"},
+                      "metadata":{
+                        "type":"object",
+                        "properties":{
+                            "version":{"type": "string"},
+                            "uri":{
+                              "type":"string",
+                              "format":"uri",
+                              "pattern":"^(https?|ftp)://"
+                           },
+                            "status":{"type": "string"},
+                            "authority":{
+                               "$ref":"#/definitions/contactDetails"
+                            },
+                            "summary": {"type": "string"},
+                            "documentation":{
+                              "type":"string",
+                              "format":"uri",
+                              "pattern":"^(https?|ftp)://"
+                           }
+                        },
+                        "additionalProperties":false
+                     }
+                  }
+               } 
             },
             "presentLoDs":{
                "$ref":"#/definitions/presentLoDs"
@@ -512,60 +582,16 @@
                   "GenericCityObject":{
                      "$ref":"#/definitions/featureData"
                   },
-                   "CityObjectGroup":{
-                     "type": "object",
-                      "properties": {
-                        "uniqueFeatureCount":{ "type":"integer" },
-                        "aggregateFeatureCount":{ "type":"integer" },
-                        "presentLoDs":{ "$ref":"#/definitions/presentLoDs" },
-                        "Building":{
-                              "$ref":"#/definitions/featureData",
-                              "BuildingParts":{ "type":"integer" },
-                              "BuildingInstallations":{ "type":"integer" }
-                            },
-                        "Bridge":{
-                            "$ref":"#/definitions/featureData",
-                            "BridgeParts":{ "type":"integer" },
-                            "BridgeInstallations":{ "type":"integer" },
-                            "BridgeConstructionElements":{ "type":"integer" }
-                          },
-                        "Tunnel":{
-                            "$ref":"#/definitions/featureData",
-                            "TunnelParts":{ "type":"number" },
-                            "TunnelInstallations":{ "type":"integer" }
-                          },
-                        "TINRelief":{
-                           "$ref":"#/definitions/featureData",
-                           "triangleCount":{ "type":"integer" } 
-                          },
-                        "Road":{
-                           "$ref":"#/definitions/featureData"
-                          },
-                        "Railway":{
-                           "$ref":"#/definitions/featureData"
-                          },
-                        "TransportSquare":{
-                            "$ref":"#/definitions/featureData"
-                          },
-                        "WaterBody":{
-                            "$ref":"#/definitions/featureData"
-                          },
-                        "PlantCover":{
-                            "$ref":"#/definitions/featureData"
-                          },
-                        "SolitaryVegetationObject":{
-                            "$ref":"#/definitions/featureData"
-                          },
-                        "LandUse":{
-                            "$ref":"#/definitions/featureData"
-                          },
-                        "CityFurniture":{
-                            "$ref":"#/definitions/featureData"
-                          },
-                        "GenericCityObject":{
-                            "$ref":"#/definitions/featureData"
-                         } 
-                      },
+                   "CityObjectGroups":{
+                     "type":"object",
+                     "properties":{
+                        "presence":{
+                           "$ref":"#/definitions/presence"
+                        },
+                        "count":{
+                           "type":"integer"
+                        }
+                     },
                       "additionalProperties":false
                   }
                 },

--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -4,56 +4,12 @@
    "definitions":{
       "presentLoDs":{
          "type":"object",
-         "properties":{
-            "0.0":{
-               "type":"integer"
-            },
-            "0.1":{
-               "type":"integer"
-            },
-            "0.2":{
-               "type":"integer"
-            },
-            "0.3":{
-               "type":"integer"
-            },
-            "1.0":{
-               "type":"integer"
-            },
-            "1.1":{
-               "type":"integer"
-            },
-            "1.2":{
-               "type":"integer"
-            },
-            "1.3":{
-               "type":"integer"
-            },
-            "2.0":{
-               "type":"integer"
-            },
-            "2.1":{
-               "type":"integer"
-            },
-            "2.2":{
-               "type":"integer"
-            },
-            "2.3":{
-               "type":"integer"
-            },
-            "3.0":{
-               "type":"integer"
-            },
-            "3.1":{
-               "type":"integer"
-            },
-            "3.2":{
-               "type":"integer"
-            },
-            "3.3":{
-               "type":"integer"
+         "patternProperties": {
+            "^[0-9](\\.[0-9])?$": {
+               "type": "integer"
             }
-         }
+         },
+         "additionalProperties":false
       },
       "presence":{
          "type":"string",


### PR DESCRIPTION
- Add present/absent variables: "templates", "geometry-templates", "transform", "extensions"
- Change date formatting in metadata to be more in-line with ISO 19115
- Simplify CityObjectGroup in metadata to avoid double counting of features
- Make presence/absence a definition in metadata schema
- Add metadata for extensions