### PR TITLE
added missing attribute 'height' to SolitaryVegetationObject

### DIFF
--- a/schemas/cityobjects.schema.json
+++ b/schemas/cityobjects.schema.json
@@ -526,6 +526,7 @@
           "attributes": {
             "properties": {
               "species": {"type": "string"},
+              "height": {"type": "number"},
               "trunkDiameter": {"type": "number"},
               "crownDiameter": {"type": "number"}
             }


### PR DESCRIPTION
Added missing attribute "height" attribute to SolitaryVegetationObject.
see CityGML documentation at page 133