### PR TITLE
Transportation additions

### DIFF
--- a/schemas/cityobjects.schema.json
+++ b/schemas/cityobjects.schema.json
@@ -1216,11 +1216,11 @@
       {
         "properties": {
           "attributes": {
-            "trafficDirectionValue": {
+            "trafficDirection": {
               "type": {
                 "enum": [
-                  "One-way",
-                  "Two-way"
+                  "one-way",
+                  "two-way"
                 ]
               }
             }

--- a/schemas/cityobjects.schema.json
+++ b/schemas/cityobjects.schema.json
@@ -1179,6 +1179,12 @@
                 "items": {
                   "type": "string"
                 }
+              },
+              "clearanceSpace": {
+                "type": "number"
+              },
+              "clearanceSpaceUnit": {
+                "type": "string"
               }
             }
           },
@@ -1205,10 +1211,31 @@
       }
     ]
   },
+  "_AbstractTransporationWay": {
+    "allOf": [
+      {
+        "properties": {
+          "attributes": {
+            "trafficDirectionValue": {
+              "type": {
+                "enum": [
+                  "One-way",
+                  "Two-way"
+                ]
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
   "Road": {
     "allOf": [
       {
         "$ref": "#/_AbstractTransportationComplex"
+      },
+      {
+        "$ref": "#/_AbstractTransporationWay"
       },
       {
         "properties": {
@@ -1253,6 +1280,28 @@
           "type": {
             "enum": [
               "TransportSquare"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      }
+    ]
+  },
+  "Waterway": {
+    "allOf": [
+      {
+        "$ref": "#/_AbstractTransportationComplex"
+      },
+      {
+        "$ref": "#/_AbstractTransporationWay"
+      },
+      {
+        "properties": {
+          "type": {
+            "enum": [
+              "Waterway"
             ]
           }
         },


### PR DESCRIPTION
This is to add CityGML v3 elements into the transportation module.

- Added waterways
- Added attributes for clearance space and direction of traffic

For the direction of traffic we assume that in case of `one-way` roads the orientation is implied by the orientation of the geometries vertices. This is because the original proposal's values (`forwards`/`backwards`) makes little sense when using a `MultiLineString` as the creator of the geometry will already have to make use that all individual linestrings are of the same orientation. Therefore, having to specify an orientation on top of that, seems unnecessary.

Special thanks to @Athelena for making the CityGML v3 changes happen.