### PR TITLE
Make changes to CityObjectGroup

### DIFF
--- a/schemas/cityobjects.schema.json
+++ b/schemas/cityobjects.schema.json
@@ -526,6 +526,20 @@
               "CityObjectGroup"
             ]
           },
+          "groupType": {
+            "enum": [
+              "road section",
+              "intersection",
+              "neighbourhood",
+              "district",
+              "ward",
+              "borough",
+              "county",
+              "postal district",
+              "electoral district",
+              "other"
+            ]
+          },
           "members": {
             "type": "array",
             "description": "the IDs of the CityObjects members of that group",
@@ -533,35 +547,18 @@
               "type": "string"
             }
           },
-          "geometry": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "geomprimitives.schema.json#/MultiPoint"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/MultiLineString"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/Solid"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/MultiSurface"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
-                }
-              ]
-            },
-            "minItems": 0,
-            "maxItems": 1
+          "spatialBoundaries": {
+            "oneOf": [
+              {
+                "$ref": "geomprimitives.schema.json#/Solid"
+              },
+              {
+                "$ref": "geomprimitives.schema.json#/MultiSolid"
+              },
+              {
+                "$ref": "geomprimitives.schema.json#/CompositeSolid"
+              }
+            ]
           }
         },
         "required": [


### PR DESCRIPTION
Additions to the CityObjectGroup.

The point is to make its use for specific use cases, instead of using it as a "dummy" object to group things. We prescribed a few cases for which they can be used (e.g. as a way to group roads together or model neighbourhoods).

Also, we remove the `geometry` property as this seems unnecessary. Instead, we add a `spatialBoundaries` property which can only be a (Multi/Composite) Solid that defines the boundaries of the area that the group represents.