### PR TITLE
Remove fixed references from CityObjectGroup property in metadata

### DIFF
--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -495,69 +495,6 @@
               },
               "presentLoDs": {
                 "$ref": "#/definitions/presentLoDs"
-              },
-              "Building": {
-                "$ref": "#/definitions/featureData",
-                "BuildingParts": {
-                  "type": "integer"
-                },
-                "BuildingInstallations": {
-                  "type": "integer"
-                }
-              },
-              "Bridge": {
-                "$ref": "#/definitions/featureData",
-                "BridgeParts": {
-                  "type": "integer"
-                },
-                "BridgeInstallations": {
-                  "type": "integer"
-                },
-                "BridgeConstructionElements": {
-                  "type": "integer"
-                }
-              },
-              "Tunnel": {
-                "$ref": "#/definitions/featureData",
-                "TunnelParts": {
-                  "type": "number"
-                },
-                "TunnelInstallations": {
-                  "type": "integer"
-                }
-              },
-              "TINRelief": {
-                "$ref": "#/definitions/featureData",
-                "triangleCount": {
-                  "type": "integer"
-                }
-              },
-              "Road": {
-                "$ref": "#/definitions/featureData"
-              },
-              "Railway": {
-                "$ref": "#/definitions/featureData"
-              },
-              "TransportSquare": {
-                "$ref": "#/definitions/featureData"
-              },
-              "WaterBody": {
-                "$ref": "#/definitions/featureData"
-              },
-              "PlantCover": {
-                "$ref": "#/definitions/featureData"
-              },
-              "SolitaryVegetationObject": {
-                "$ref": "#/definitions/featureData"
-              },
-              "LandUse": {
-                "$ref": "#/definitions/featureData"
-              },
-              "CityFurniture": {
-                "$ref": "#/definitions/featureData"
-              },
-              "GenericCityObject": {
-                "$ref": "#/definitions/featureData"
               }
             },
             "additionalProperties": false


### PR DESCRIPTION
There is no need to aggregate objects at this level, so it is removed for now.

There are still some fixed names at the metadata level but I am not sure what's the best way to deal with them now so I'll leave it as it it.