### PR TITLE
Harmonize geometry types between the different city objects

### DIFF
--- a/schemas/cityobjects.schema.json
+++ b/schemas/cityobjects.schema.json
@@ -61,13 +61,28 @@
             "items": {
               "oneOf": [
                 {
+                  "$ref": "geomprimitives.schema.json#/MultiPoint"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/MultiLineString"
+                },
+                {
                   "$ref": "geomprimitives.schema.json#/MultiSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/Solid"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSolid"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/MultiSolid"
+                },
+                {
+                  "$ref": "geomtemplates.schema.json#/GeometryInstance"
                 }
               ]
             }
@@ -103,6 +118,9 @@
               "oneOf": [
                 {
                   "$ref": "geomprimitives.schema.json#/MultiSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/Solid"
@@ -179,19 +197,70 @@
                   "$ref": "geomprimitives.schema.json#/MultiLineString"
                 },
                 {
+                  "$ref": "geomprimitives.schema.json#/MultiSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
                   "$ref": "geomprimitives.schema.json#/Solid"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/MultiSolid"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
+                  "$ref": "geomtemplates.schema.json#/GeometryInstance"
+                }
+              ]
+            }
+          }
+        },
+        "required": [
+          "type",
+          "parents"
+        ]
+      }
+    ]
+  },
+  "BuildingConstructiveElement": {
+    "allOf": [
+      {
+        "$ref": "#/_AbstractCityObject"
+      },
+      {
+        "properties": {
+          "type": {
+            "enum": [
+              "BuildingConstructiveElement"
+            ]
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "geomprimitives.schema.json#/MultiPoint"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/MultiLineString"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/MultiSolid"
                 },
                 {
                   "$ref": "geomtemplates.schema.json#/GeometryInstance"
@@ -218,6 +287,37 @@
             "enum": [
               "BuildingFurniture"
             ]
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "geomprimitives.schema.json#/MultiPoint"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/MultiLineString"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/MultiSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/MultiSolid"
+                },
+                {
+                  "$ref": "geomtemplates.schema.json#/GeometryInstance"
+                }
+              ]
+            }
           }
         },
         "required": [
@@ -244,16 +344,16 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "geomprimitives.schema.json#/Solid"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
-                },
-                {
                   "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 }
               ]
             }
@@ -283,16 +383,16 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "geomprimitives.schema.json#/Solid"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
-                },
-                {
                   "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 }
               ]
             }
@@ -322,16 +422,16 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "geomprimitives.schema.json#/Solid"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
-                },
-                {
                   "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 }
               ]
             }
@@ -374,19 +474,19 @@
                   "$ref": "geomprimitives.schema.json#/MultiLineString"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/Solid"
+                  "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
+                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSurface"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                  "$ref": "geomprimitives.schema.json#/MultiSolid"
                 }
               ]
             }
@@ -424,9 +524,6 @@
                 },
                 {               
                   "$ref": "geomprimitives.schema.json#/Solid"
-                },
-                {               
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSolid"
@@ -466,9 +563,6 @@
                 {               
                   "$ref": "geomprimitives.schema.json#/Solid"
                 },
-                {               
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
-                },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 }
@@ -506,19 +600,19 @@
                   "$ref": "geomprimitives.schema.json#/MultiLineString"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/Solid"
+                  "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
+                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSurface"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                  "$ref": "geomprimitives.schema.json#/MultiSolid"
                 },
                 {
                   "$ref": "geomtemplates.schema.json#/GeometryInstance"
@@ -557,19 +651,19 @@
                   "$ref": "geomprimitives.schema.json#/MultiLineString"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/Solid"
+                  "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
+                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSurface"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                  "$ref": "geomprimitives.schema.json#/MultiSolid"
                 },
                 {
                   "$ref": "geomtemplates.schema.json#/GeometryInstance"
@@ -602,28 +696,16 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiPoint"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/MultiLineString"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/Solid"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
-                },
-                {
                   "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSurface"
                 },
                 {
-                  "$ref": "geomtemplates.schema.json#/GeometryInstance"
+                  "$ref": "geomprimitives.schema.json#/Solid"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 }
               ]
             }
@@ -659,19 +741,19 @@
                   "$ref": "geomprimitives.schema.json#/MultiLineString"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/Solid"
+                  "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
+                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSurface"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                  "$ref": "geomprimitives.schema.json#/MultiSolid"
                 },
                 {
                   "$ref": "geomtemplates.schema.json#/GeometryInstance"
@@ -725,9 +807,6 @@
                   "$ref": "geomprimitives.schema.json#/Solid"
                 },
                 {               
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
-                },
-                {
                   "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 }
               ]
@@ -777,9 +856,6 @@
                   "$ref": "geomprimitives.schema.json#/Solid"
                 },
                 {               
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
-                },
-                {
                   "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 }
               ]
@@ -816,19 +892,19 @@
                   "$ref": "geomprimitives.schema.json#/MultiLineString"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/Solid"
+                  "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
+                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSurface"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                  "$ref": "geomprimitives.schema.json#/MultiSolid"
                 },
                 {
                   "$ref": "geomtemplates.schema.json#/GeometryInstance"
@@ -867,19 +943,19 @@
                   "$ref": "geomprimitives.schema.json#/MultiLineString"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/Solid"
+                  "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
+                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSurface"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                  "$ref": "geomprimitives.schema.json#/MultiSolid"
                 },
                 {
                   "$ref": "geomtemplates.schema.json#/GeometryInstance"
@@ -912,28 +988,16 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiPoint"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/MultiLineString"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/Solid"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
-                },
-                {
                   "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSurface"
                 },
                 {
-                  "$ref": "geomtemplates.schema.json#/GeometryInstance"
+                  "$ref": "geomprimitives.schema.json#/Solid"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 }
               ]
             }
@@ -969,19 +1033,19 @@
                   "$ref": "geomprimitives.schema.json#/MultiLineString"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/Solid"
+                  "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
+                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSurface"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                  "$ref": "geomprimitives.schema.json#/MultiSolid"
                 },
                 {
                   "$ref": "geomtemplates.schema.json#/GeometryInstance"
@@ -1010,13 +1074,13 @@
             "items": {
               "oneOf": [
                 {
+                  "$ref": "geomprimitives.schema.json#/MultiLineString"
+                },
+                {
                   "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSurface"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/MultiLineString"
                 }
               ]
             }
@@ -1188,10 +1252,19 @@
             "items": {
               "oneOf": [
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
+                  "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSurface"
+                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/CompositeSolid"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/MultiSolid"
                 }
               ]
             }
@@ -1226,19 +1299,19 @@
                   "$ref": "geomprimitives.schema.json#/MultiLineString"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/Solid"
+                  "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
+                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSurface"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                  "$ref": "geomprimitives.schema.json#/MultiSolid"
                 },
                 {
                   "$ref": "geomtemplates.schema.json#/GeometryInstance"
@@ -1308,19 +1381,19 @@
                   "$ref": "geomprimitives.schema.json#/MultiLineString"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/Solid"
+                  "$ref": "geomprimitives.schema.json#/MultiSurface"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSolid"
+                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                },
+                {
+                  "$ref": "geomprimitives.schema.json#/Solid"
                 },
                 {
                   "$ref": "geomprimitives.schema.json#/CompositeSolid"
                 },
                 {
-                  "$ref": "geomprimitives.schema.json#/MultiSurface"
-                },
-                {
-                  "$ref": "geomprimitives.schema.json#/CompositeSurface"
+                  "$ref": "geomprimitives.schema.json#/MultiSolid"
                 },
                 {
                   "$ref": "geomtemplates.schema.json#/GeometryInstance"

--- a/specs/specs.bs
+++ b/specs/specs.bs
@@ -223,7 +223,7 @@ Six City Objects are related to bridges:
  - `"BridgeFurniture"`
 
 
-The geometry of both `"Bridge"` and `"BridgePart"` can only be represented with these Geometry Objects: (1) `"Solid"`, (2) `"CompositeSolid"`, (3) `"MultiSurface"`.
+The geometry of both `"Bridge"` and `"BridgePart"` can only be represented with these Geometry Objects: (1) `"Solid"`, (2) `"CompositeSolid"`, (3) `"MultiSurface"`, (4) `"CompositeSurface"`.
 The geometry of the four other objects can be represented with any of the Geometry Objects.
 
 A City Object of type `"Bridge"` or `"BridgePart"` may have a member `"address"`, whose value is an array of JSON objects listing the potentially several addresses of that bridge . 
@@ -274,7 +274,7 @@ Eight City Objects are related to buildings:
 <!-- this in the schema... perhaps in cjio -->
 
 The geometry of `"Building"`, `"BuildingPart"`, `"BuildingStorey"`, `"BuildingRoom"`, 
-and `"BuildingUnit"` can only be represented with these Geometry Objects: (1) `"Solid"`, (2) `"CompositeSolid"`, (3) `"MultiSurface"`.
+and `"BuildingUnit"` can only be represented with these Geometry Objects: (1) `"Solid"`, (2) `"CompositeSolid"`, (3) `"MultiSurface"`, (4) `"CompositeSurface"`.
 
 All of the eight, except `"Building"`, must have a `"parents"` property.
 The installations, furnitures, and subdivisions can have as parents a `"Building"`, a `"BuildingPart"`, or a `"BuildingRoom"`.
@@ -349,7 +349,7 @@ If a location is necessary (eg to locate the position of the front door) then a 
 
 ## CityFurniture
 
-The geometry of a City Object of type `"CityFurniture"` can be any of the following: `"MultiPoint"`, `"MultiLineString"`, `"MultiSurface"`, `"CompositeSurface"`, `"Solid"`, or `"CompositeSolid"`.
+The geometry of a City Object of type `"CityFurniture"` can be any Geometry Object.
 
 ```json
 "mystopsign": {
@@ -445,6 +445,7 @@ Examples are:
   - shed
   - windmill
 
+The geometry of a City Object of type `"OtherConstruction"` can be any Geometry Object.
 
 ```json
 "mypylon": {
@@ -466,7 +467,7 @@ Examples are:
 
 ## PlantCover
 
-The geometry of a City Object of type `"PlantCover"` can be of type `"MultiSurface"` or `"MultiSolid"`.
+The geometry of a City Object of type `"PlantCover"` can be of type: (1) `"Solid"`, (2) `"CompositeSolid"`, (3) `"MultiSolid"`, (4) `"MultiSurface"`, (5) `"CompositeSurface"`.
 
 ```json
 "myplants": {
@@ -492,7 +493,7 @@ The geometry of a City Object of type `"PlantCover"` can be of type `"MultiSurfa
 
 ## SolitaryVegetationObject
 
-The geometry of a City Object of type `"SolitaryVegetationObject"` can be any of the following: `"MultiPoint"`, `"MultiLineString"`, `"MultiSurface"`, `"CompositeSurface"`, `"Solid"`, or `"CompositeSolid"`.
+The geometry of a City Object of type `"SolitaryVegetationObject"` can be any Geometry Object.
 
 ```json
 "onebigtree": {
@@ -612,7 +613,7 @@ Six City Objects are related to tunnels:
   - `"TunnelHollowSpace"`
   - `"TunnelFurniture"`
 
-The geometry of both `"Tunnel"` and `"TunnelPart"` can only be represented with these Geometry Objects: (1) `"Solid"`, (2) `"CompositeSolid"`, (3) `"MultiSurface"`.
+The geometry of both `"Tunnel"` and `"TunnelPart"` can only be represented with these Geometry Objects: (1) `"Solid"`, (2) `"CompositeSolid"`, (3) `"MultiSurface"`, (4) `"CompositeSurface"`.
 
 The geometry of the other four objects can be represented with any of the Geometry Objects.
 


### PR DESCRIPTION
As raised in #100, similar CityObject types such as `"Building"` and `"Bridge"` or `"BuildingRoom"` and `"BridgeRoom"` have a different set of allowed geometry types. This PR proposes a resolution.

In addition:
* Missing geometry types for `"BuildingFurniture"` have been added
* The missing `"BuildingConstructiveElement"` type has been added
* Geometry types for `"OtherConstruction"` have been adapted to allow more geometries and templates (similar to `"CityFurniture"`)