### PR TITLE
CityJSON object must be valid when used with CityJSONFeature

### DIFF
--- a/specs/specs.bs
+++ b/specs/specs.bs
@@ -1470,10 +1470,17 @@ The following root property of a CityJSON Object are not allowed in a CityJSONFe
   - `"geometry-templates"`: these should be resolved/dereferenced
   - `"extensions"`: these should be in the metadata or collection
 
-These properties may be accessible, for instance as a JSON object (the first one) in a [JSON Lines text](https://jsonlines.org/) stream, as in the following example:
+Note that a CityJSON Feature Object does not contain all the information that is required for parsing the feature.
+Most commonly, the tranformation properties (the Transform Object) and CRS need to be known by the client in order to obtain correctly located CityObjects.
+These properties may be known by the client upfront, or they may be accessible in a CityJSON object, which is sent as the first object in a [JSON Lines text](https://jsonlines.org/) stream, or in other ways not described here.
+
+In case the properties are stored in a CityJSON object, this CityJSON object still needs to be a valid CityJSON Object.
+This implies that the CityJSON object must contain all the required properties, including `"CityObjects"` and `"vertices"`, even though they are empty, because this information is stored in the subsequent CityJSON Features.
+
+Below is an example of a CityJSONFeature stream (or a JSON Lines text file), with a CityJSON object storing the metadata and transformation properties:
 
 ```json
-{"type": "CityJSON","version": "1.1","transform":{...},"metadata":{...}}
+{"type": "CityJSON","version": "1.1","transform":{...},"CityObjects":{},"metadata":{...},"vertices":[]}
 {"type": "CityJSONFeature", "id": "a", "CityObjects":{...},"vertices":[...]} 
 {"type": "CityJSONFeature", "id": "b", "CityObjects":{...},"vertices":[...]} 
 {"type": "CityJSONFeature", "id": "c", "CityObjects":{...},"vertices":[...]} 

--- a/specs/specs.bs
+++ b/specs/specs.bs
@@ -1480,10 +1480,10 @@ This implies that the CityJSON object must contain all the required properties, 
 Below is an example of a CityJSONFeature stream (or a JSON Lines text file), with a CityJSON Object storing the metadata and transformation properties:
 
 ```json
-{"type": "CityJSON","version": "1.1","transform":{...},"CityObjects":{},"metadata":{...},"vertices":[]}
-{"type": "CityJSONFeature", "id": "a", "CityObjects":{...},"vertices":[...]} 
-{"type": "CityJSONFeature", "id": "b", "CityObjects":{...},"vertices":[...]} 
-{"type": "CityJSONFeature", "id": "c", "CityObjects":{...},"vertices":[...]} 
+{"type":"CityJSON","version":"1.1","transform":{...},"CityObjects":{},"metadata":{...},"vertices":[]}
+{"type":"CityJSONFeature","id":"a","CityObjects":{...},"vertices":[...]} 
+{"type":"CityJSONFeature","id":"b","CityObjects":{...},"vertices":[...]} 
+{"type":"CityJSONFeature","id":"c","CityObjects":{...},"vertices":[...]} 
 ```
 <div class="note">
 CityJSON does not prescribe the format or standard that should be used to store several JSON objects in a given file, it only defines how `"CityJSON"` and `"CityJSONFeature"` objects should be defined.

--- a/specs/specs.bs
+++ b/specs/specs.bs
@@ -1471,13 +1471,13 @@ The following root property of a CityJSON Object are not allowed in a CityJSONFe
   - `"extensions"`: these should be in the metadata or collection
 
 Note that a CityJSON Feature Object does not contain all the information that is required for parsing the feature.
-Most commonly, the tranformation properties (the Transform Object) and CRS need to be known by the client in order to obtain correctly located CityObjects.
-These properties may be known by the client upfront, or they may be accessible in a CityJSON object, which is sent as the first object in a [JSON Lines text](https://jsonlines.org/) stream, or in other ways not described here.
+Most commonly, the tranformation properties (the Transform Object) and CRS need to be known by the client in order to correctly georeference the City Objects.
+These properties may be known by the client upfront, or they may be accessible in a CityJSON Object, which is sent as the first object in a [JSON Lines text](https://jsonlines.org/) stream, or in other ways not described here.
 
-In case the properties are stored in a CityJSON object, this CityJSON object still needs to be a valid CityJSON Object.
+In case the properties are stored in a CityJSON Object, this object needs to be a valid CityJSON Object.
 This implies that the CityJSON object must contain all the required properties, including `"CityObjects"` and `"vertices"`, even though they are empty, because this information is stored in the subsequent CityJSON Features.
 
-Below is an example of a CityJSONFeature stream (or a JSON Lines text file), with a CityJSON object storing the metadata and transformation properties:
+Below is an example of a CityJSONFeature stream (or a JSON Lines text file), with a CityJSON Object storing the metadata and transformation properties:
 
 ```json
 {"type": "CityJSON","version": "1.1","transform":{...},"CityObjects":{},"metadata":{...},"vertices":[]}
@@ -1485,9 +1485,9 @@ Below is an example of a CityJSONFeature stream (or a JSON Lines text file), wit
 {"type": "CityJSONFeature", "id": "b", "CityObjects":{...},"vertices":[...]} 
 {"type": "CityJSONFeature", "id": "c", "CityObjects":{...},"vertices":[...]} 
 ```
-
-However, it should be noticed that CityJSON does not prescribe the format or standard that should be used to store several JSON objects in a given file, it only defines how `"CityJSON"` and `"CityJSONFeature"` objects should be defined.
-
+<div class="note">
+CityJSON does not prescribe the format or standard that should be used to store several JSON objects in a given file, it only defines how `"CityJSON"` and `"CityJSONFeature"` objects should be defined.
+</div>
 
 # Extensions 
 


### PR DESCRIPTION
+ Clarify how CityJSON + CityJSONFeature works
+ Fix stream example

The old text said *"These properties may be accessible, for instance as **a JSON object** (the first one)"*.
And then in the stream example there was a `{"type": "CityJSON","version": "1.1","transform":{...},"metadata":{...}}`, which is invalid CityJSON btw.

This was very confusing, because the example suggested that the first json object should also be a CityJSON object, but the description only mentioned **a** JSON object, thus any JSON object.

IMO it is better to stick to what is already in the specs, such as using CityJSON objects. But this implies that this object must be valid, even if it has redundant, empty properties (`CityObjects`, `vertices`). This makes for a cleaner implementation.
Because if the first object is not valid CityJSON, then the transfrom, CRS properties can be stored in whatever member of the JSON object and then the cityjson client cannot parse them.