### PR TITLE
Fix "url" in extension schema

### DIFF
--- a/extensions/extension.schema.json
+++ b/extensions/extension.schema.json
@@ -33,10 +33,10 @@
       "pattern": "^(\\d\\.)(\\d)$"
     },
 
-    "uri": { 
+    "url": {
       "type": "string",
       "format": "uri-reference",
-      "description": "good to host the extension at a URI so that others can access it"
+      "description": "good to host the extension at a URL so that others can access it"
     },
 
     "description": { "type": "string" },


### PR DESCRIPTION
It was missed by 87720c17878495f927a87889407f675e91e60635 

However, the `uri` needs to stay in the validation in order to preserve compatibility with v1.1.

```json
"anyOf": [
    {
      "required": [
        "url"
      ]
    },
    {
      "required": [
        "uri"
      ]
    }
  ],
```

