### PR TITLE
Fixing typos

### DIFF
--- a/specs/specs.bs
+++ b/specs/specs.bs
@@ -889,7 +889,7 @@ If a geometry is a `MultiPoint` or a `MultiLineString`, then the primitives are 
 
 A Semantic Object:
 
-  - **must** have one member with the name `"type"`. The value is one of the allowed value. These depend on the City Object (see below).
+  - **must** have one member with the name `"type"`. The value is one of the allowed values. These depend on the City Object (see below).
   - **may** have an attribute `"parent"`. The value is an integer pointing to another Semantic Object of the same geometry (index of it, 0-based). This is used to explicitly represent to which wall or roof a window or door belongs to; there can be only one parent.
   - **may** have an attribute `"children"`. The value is an array of integers pointing to other Semantic Objects of the same geometry (index of it, 0-based). This is used to explicitly represent the openings (windows and doors) of walls and roofs.
   - **may** have other attributes in the form of a JSON key-value pair, where the value must not be a JSON object (but a string/number/integer/boolean).

--- a/specs/specs.bs
+++ b/specs/specs.bs
@@ -300,7 +300,7 @@ The geometry of `"Building"`, `"BuildingPart"`, `"BuildingStorey"`, `"BuildingRo
 and `"BuildingUnit"` can only be represented with these Geometry Objects: (1) `"Solid"`, (2) `"CompositeSolid"`, (3) `"MultiSurface"`, (4) `"CompositeSurface"`.
 
 All eight City Objects, except `"Building"`, must have a `"parents"` property.
-The installations, furnitures, and subdivisions can have as parents a `"Building"`, a `"BuildingPart"`, or a `"BuildingRoom"`.
+The installations, furniture, and subdivisions can have as parents a `"Building"`, a `"BuildingPart"`, or a `"BuildingRoom"`.
 
 The geometry of `"BuildingInstallation"`, `"BuildingConstructiveElement"`, or  `"BuildingFurniture"` objects can be represented with any of the Geometry Objects.
 
@@ -1456,15 +1456,15 @@ Each part becomes a CityJSON file.
 Another solution is to decompose a CityJSON object into its *features* (the City Objects), create several JSON objects, and store them in a [JSON Lines text](https://jsonlines.org) (also called [Newline Delimited JSON](http://ndjson.org)).
 This is a format to store several JSON objects in a single file, and allows the processing of each object one at a time.
 
-A CityJSON Feature Object allows storage of one feature, for instance a `"Building"` with eventually its children `"BuildingPart"` and/or `"BuildingInstallation"`.
+A CityJSON Feature Object allows the storage of a single feature, for instance a `"Building"` together with its children (of type `"BuildingPart"` and/or `"BuildingInstallation"`).
 Unlike a CityJSON Object, all the vertices and appearances of the object are *local*.
 
 A CityJSON Feature Object:
 
   - is a JSON object.
   - **must** have one member with the name `"type"`. The value must be `"CityJSONFeature"`.
-  - **must** have one member with the name `"id"`. The value must be a string representing the identifier of the City Object Feature, this is used to clearly identify which of the CityObjects is the parent.
-  - **must** have one member with the name `"CityObjects"`. The value of this member is a collection of key-value pairs, where the key is the ID of the object, and the value is one City Object. The ID of a City Object should be unique (within one `"CityJSONFeature"`), and all the children of the `"CityJSONFeature"` must be included (and the children of the children (recursively), if there are any).
+  - **must** have one member with the name `"id"`. The value must be a string representing the identifier of the City Object Feature. This is used to clearly identify which of the CityObjects is the parent.
+  - **must** have one member with the name `"CityObjects"`. The value is a collection of key-value pairs, where the key is the ID of the object, and the value is one City Object. The ID of a City Object should be unique (within one `"CityJSONFeature"`), and all the children of the `"CityJSONFeature"` must be included (and the children of the children (recursively), if there are any).
   - **must** have one member with the name `"vertices"`. The value is an array of coordinates of each vertex of the current City Object Feature (stored with integers). Their position in this array (0-based) is used as an index to be referenced by the Geometry Objects for the JSON object (warning: the vertices are local to the JSON object).
   - **may** have one member with the name `"appearance"`. The value may contain JSON objects representing the textures and/or materials of surfaces. See [[#appearance-object]] for details.
   - **must not** have other members.
@@ -1508,13 +1508,13 @@ A CityJSON Feature Object:
 }
 ```
 
-The following root property of a CityJSON Object are not allowed in a CityJSONFeature Object:
+The following root properties of a CityJSON Object are not allowed in a CityJSONFeature Object:
 
   - `"transform"` 
   - `"version"` 
   - `"metadata"` 
-  - `"geometry-templates"`: these should either be resolved/dereferenced, or put in the metadata or collection
-  - `"extensions"`: these should be in the metadata or collection
+  - `"geometry-templates"`: these should either be resolved/dereferenced, or they should be placed in the metadata or collection
+  - `"extensions"`: these should be placed in the metadata or collection
 
 Note that a CityJSON Feature Object does not contain all the information that is required for parsing the feature.
 Most commonly, the transformation properties (the Transform Object) and CRS need to be known by the client in order to correctly georeference the City Objects.
@@ -1545,7 +1545,7 @@ Observe that CityJSON does not prescribe the format or standard that should be u
 CityJSON uses [JSON Schemas](http://json-schema.org/) to document and validate its data model, including its Extensions. Schemas offer a way to validate the syntax of a JSON document, and thus the possibility to require certain JSON members.
 Therefore, for writing more complex Extensions, a basic familiarity with [JSON Schemas](http://json-schema.org/) is advised.
 
-A CityJSON *Extension* is a JSON file that documents how the core data model of CityJSON is extended, and is also used for validating the CityJSON files.
+A CityJSON *Extension* is a JSON file that documents how the core data model of CityJSON is extended, and it is also used for validating the CityJSON files.
 This is conceptually akin to the [Application Domain Extensions (ADEs)](https://docs.ogc.org/is/20-010/20-010.html#toc66) in CityGML.
 
 A CityJSON Extension can extend the core data model in four ways:
@@ -1558,11 +1558,11 @@ A CityJSON Extension can extend the core data model in four ways:
 <div class="note">
   While Extensions are less flexible than CityGML ADEs (inheritance and namespaces are for instance not supported, and less customisation is possible), it should be noted that the flexibility of ADEs comes at a price: the software processing an extended CityGML file will not necessarily know what structure to expect.
 
-  There is ongoing work to use the ADE schemas to automatically do this, but this currently is not supported by most software. 
+  There is ongoing work on using the ADE schemas to automatically do this, but this is currently not supported by most software. 
   Viewers might not be affected by ADEs because the geometries are usually not changed by an ADE (although they can!). 
   However, software parsing the XML to extract attributes and features might not work directly (and thus specific code would need to be written).
 
-  CityJSON Extensions are designed such that they can be read and processed by standard CityJSON software, often no changes in the parsing code is required. 
+  CityJSON Extensions should be designed in such a way that they can be read and processed by standard CityJSON software, without demanding changes in the parsing code. 
   This is achieved by enforcing a set of 6 simple rules (see [[#rules-to-follow-to-define-new-city-objects]]) when adding new City Objects. 
   If these are followed, then a CityJSON file containing Extensions will be seen as a "standard" CityJSON file.
 </div>

--- a/specs/specs.bs
+++ b/specs/specs.bs
@@ -1421,7 +1421,7 @@ A Texture Object:
 
 ## Vertices-texture Object
 
-An Appearance Object may have a member with the name `"vertices-texture"`. 
+An Appearance Object may have one member with the name `"vertices-texture"`. 
 Its value is an array of the *(u,v)* coordinates of the vertices used for texturing surfaces.
 Their position in this array (0-based) is used by the `"texture"` member of the Geometry Objects.
 

--- a/specs/specs.bs
+++ b/specs/specs.bs
@@ -1508,7 +1508,7 @@ A CityJSON Feature Object:
 }
 ```
 
-The following root properties of a CityJSON Object are not allowed in a CityJSONFeature Object:
+The following root members of a CityJSON Object are not allowed in a CityJSONFeature Object:
 
   - `"transform"` 
   - `"version"` 

--- a/specs/specs.bs
+++ b/specs/specs.bs
@@ -1562,7 +1562,7 @@ A CityJSON Extension can extend the core data model in four ways:
   Viewers might not be affected by ADEs because the geometries are usually not changed by an ADE (although they can!). 
   However, software parsing the XML to extract attributes and features might not work directly (and thus specific code would need to be written).
 
-  CityJSON Extensions should be designed in such a way that they can be read and processed by standard CityJSON software, without demanding changes in the parsing code. 
+  CityJSON Extensions are designed in a way that they can be read and processed by standard CityJSON software, often without requiring any changes in the parsing code. 
   This is achieved by enforcing a set of 6 simple rules (see [[#rules-to-follow-to-define-new-city-objects]]) when adding new City Objects. 
   If these are followed, then a CityJSON file containing Extensions will be seen as a "standard" CityJSON file.
 </div>

--- a/specs/specs.bs
+++ b/specs/specs.bs
@@ -125,12 +125,12 @@ There are 2 kinds of City Objects:
   2.  **2nd-level**: City Objects that need to have a `"parents"` to exist.
 
 This is because the schema of CityGML has been flattened.
-For example, a `"BuildingInstallation"` cannot be present in a dataset without being the `"children"` of a `"Building"`, but a `"Building"` can be present by itself.
+For example, `"BuildingInstallation"` instances cannot be present in a dataset without being `"children"` of a `"Building"`, but a `"Building"` can be present by itself.
 </div>
 
 A City Object:
 
-  - **must** have one member `"type"`. The value is one of the possibilities in the figure above (of type string). If an Extension is used, then the type can be any string starting with a `"+"`, as explained in [[#extensions]].
+  - **must** have one member with the name `"type"`. The value is one of the possibilities in the figure above (of type string). If an Extension is used, then the type can be any string starting with a `"+"`, as explained in [[#extensions]].
   - **may** have one member with the name `"geometry"`. The value is an array containing 0 or more Geometry Objects. More than one Geometry Object is used to represent several different levels-of-detail (LoDs) for the same object. However, the different Geometry Objects of a given City Object do not have to be of different LoDs.
   - **may** have one member with the name `"attributes"`. The value is an object where the attributes of the City Object are listed.
   - **may** have one member with the name `"geographicalExtent"` (the axis-aligned bounding box of the City Object). The value is an array with 6 values: `[minx, miny, minz, maxx, maxy, maxz]`
@@ -138,8 +138,8 @@ A City Object:
 
 A City Object of type 2nd-level:
 
-  - **must** have one member `"parents"`. The value is an array of the IDs (of type string) of the City Objects that are its parents. For the City Objects in the CityJSON core module, this array will always be of size 1 (only one parent). New City Objects defined in extensions can have more than one parents.
-  - **may** have one member `"children"`, and the `"children"` array only references the City Objects that are one level below the current one in the hierarchy. For instance a `"BuildingPart"` that contains a `"BuildingInstallation"`.
+  - **must** have one member `"parents"`. The value is an array with the IDs (of type string) of the City Object's parents. For the City Objects in the CityJSON core module, this array will always be of size 1 (only one parent). New City Objects defined in extensions can have more than one parent.
+  - **may** have one member `"children"`. The value is an array with the IDs (of type string) of the City Object's children. The array references only the City Objects that are one level below the current one in the hierarchy. For instance, the `"children"` array for the object "id-1" below links to a `"BuildingPart"` but not to the `"BuildingInstallation"` which is a child of the `"BuildingPart"`.
 
 ```json
 "CityObjects": {

--- a/specs/specs.bs
+++ b/specs/specs.bs
@@ -1267,7 +1267,6 @@ An Appearance Object is a JSON object that
 
   - **may** have one member with the name `"materials"`, whose value is an array of Material Objects.
   - **may** have one member with the name `"textures"`, whose value is an array of Texture Objects.
-  - **may** have both `"materials"` and `"textures"`.
   - **may** have one member with the name `"vertices-texture"`, whose value is an array of coordinates of each so-called UV vertex of the city model.
   - **may** have one member with the name `"default-theme-texture"`, whose value is the name of the default theme for the appearance (a string). This can be used if geometries have more than one textures, so that a viewer displays the default one.
   - **may** have one member with the name `"default-theme-material"`, whose value is the name of the default theme for the material (a string). This can be used if geometries have more than one textures, so that a viewer displays the default one.

--- a/specs/specs.bs
+++ b/specs/specs.bs
@@ -134,12 +134,12 @@ A City Object:
   - **may** have one member with the name `"geometry"`. The value is an array containing 0 or more Geometry Objects. More than one Geometry Object is used to represent several different levels-of-detail (LoDs) for the same object. However, the different Geometry Objects of a given City Object do not have to be of different LoDs.
   - **may** have one member with the name `"attributes"`. The value is an object where the attributes of the City Object are listed.
   - **may** have one member with the name `"geographicalExtent"` (the axis-aligned bounding box of the City Object). The value is an array with 6 values: `[minx, miny, minz, maxx, maxy, maxz]`
-  - **may** have one member `"children"`. The value is an array of the IDs (of type string) of the 2nd-level City Objects that are part of the 1st-level City Object. Only the direct children of the City Object are listed, not the grandchildren. Also, a City Object can have different types of City Objects as children, eg a `"Building"` can have both as children `"BuildingPart"` and `"BuildingInstallation"`. The order of the children in the array is not relevant.
+  - **may** have one member with the name `"children"`. The value is an array of the IDs (of type string) of the 2nd-level City Objects that are part of the 1st-level City Object. Only the direct children of the City Object are listed, not the grandchildren. Also, a City Object can have different types of City Objects as children, eg a `"Building"` can have both as children `"BuildingPart"` and `"BuildingInstallation"`. The order of the children in the array is not relevant.
 
 A City Object of type 2nd-level:
 
-  - **must** have one member `"parents"`. The value is an array with the IDs (of type string) of the City Object's parents. For the City Objects in the CityJSON core module, this array will always be of size 1 (only one parent). New City Objects defined in extensions can have more than one parent.
-  - **may** have one member `"children"`. The value is an array with the IDs (of type string) of the City Object's children. The array references only the City Objects that are one level below the current one in the hierarchy. For instance, the `"children"` array for the object "id-1" below links to a `"BuildingPart"` but not to the `"BuildingInstallation"` which is a child of the `"BuildingPart"`.
+  - **must** have one member with the name `"parents"`. The value is an array with the IDs (of type string) of the City Object's parents. For the City Objects in the CityJSON core module, this array will always be of size 1 (only one parent). New City Objects defined in extensions can have more than one parent.
+  - **may** have one member with the name `"children"`. The value is an array with the IDs (of type string) of the City Object's children. The array references only the City Objects that are one level below the current one in the hierarchy. For instance, the `"children"` array for the object "id-1" below links to a `"BuildingPart"` but not to the `"BuildingInstallation"` which is a child of the `"BuildingPart"`.
 
 ```json
 "CityObjects": {
@@ -408,10 +408,10 @@ Since a `"CityObjectGroup"` is also a City Object, it can be part of another gro
 
 A City Object of type `"CityObjectGroup"`:
 
-  - **must** have a member `"children"`. The value is an array of the IDs of the City Objects that the group contains. As for other City Objects, the City Objects must have the ID of the group in `"parents"`.
-  - **may** have a member `"children_roles"`, whose value is an array of strings describing the role of each City Object in the group. This member must be of the same length as that of `"children"`.
-  - **may** have a member `"attributes"`.
-  - **may** have a member `"geometry"`. Notice that since the `"CityObjectGroup"` is a container of different City Objects, the concept of Level of Detail does not apply to it. Nevertheless, the `"lod"` property is still used for enforcing uniformity with all the other geometries.
+  - **must** have one member with the name `"children"`. The value is an array of the IDs of the City Objects that the group contains. As for other City Objects, the City Objects must have the ID of the group in `"parents"`.
+  - **may** have one member with the name `"children_roles"`, whose value is an array of strings describing the role of each City Object in the group. This member must be of the same length as that of `"children"`.
+  - **may** have one member with the name `"attributes"`.
+  - **may** have one member with the name `"geometry"`. Notice that since the `"CityObjectGroup"` is a container of different City Objects, the concept of Level of Detail does not apply to it. Nevertheless, the `"lod"` property is still used for enforcing uniformity with all the other geometries.
 
 
 ```json
@@ -770,10 +770,10 @@ A Geometry object:
 
  - **must** have one member with the name `"type"`. The value must be a string with one of the 8 allowed Geometry types, as defined above.
  - **must** have one member with the name `"lod"`. The value must be a string with the LoD identifying the level-of-detail (LoD) of the geometry. This can be either a single digit (following the CityGML standards), or "X.Y"-formatted if the [improved LoDs by TU Delft](https://3d.bk.tudelft.nl/lod) are used.
- - **must** have one member with the name `"boundaries"`. The value is a hierarchy of arrays (the depth depends on the Geometry object) with integers. An integer refers to the index in the `"vertices"` array of the CityJSON object, and it is 0-based (ie the first element in the array has the index "0", the second one "1", etc.).
- - **may** have one member `"semantics"`. The value is a JSON Object, as defined below.
- - **may** have one member `"material"`. The value is a JSON Object, as defined below.
- - **may** have one member `"texture"`. The value is a JSON Object, as defined below.
+ - **must** have one member with the name `"boundaries"`. The value is a hierarchy of arrays (the depth depends on the Geometry object) with integers. Each integer refers to an index in the `"vertices"` array of the CityJSON object, and it is 0-based (ie the first element in the array has the index "0", the second one "1", etc.).
+ - **may** have one member with the name `"semantics"`. The value is a JSON Object, as defined below.
+ - **may** have one member with the name `"material"`. The value is a JSON Object, as defined below.
+ - **may** have one member with the name `"texture"`. The value is a JSON Object, as defined below.
 
 
 <div class="note"> 
@@ -890,9 +890,9 @@ If a geometry is a `MultiPoint` or a `MultiLineString`, then the primitives are 
 A Semantic Object:
 
   - **must** have one member with the name `"type"`. The value is one of the allowed values. These depend on the City Object (see below).
-  - **may** have an attribute `"parent"`. The value is an integer pointing to another Semantic Object of the same geometry (index of it, 0-based). This is used to explicitly represent to which wall or roof a window or door belongs to; there can be only one parent.
-  - **may** have an attribute `"children"`. The value is an array of integers pointing to other Semantic Objects of the same geometry (index of it, 0-based). This is used to explicitly represent the openings (windows and doors) of walls and roofs.
-  - **may** have other attributes in the form of a JSON key-value pair, where the value must not be a JSON object (but a string/number/integer/boolean).
+  - **may** have one member with the name `"parent"`. The value is an integer pointing to another Semantic Object of the same geometry (index of it, 0-based). This is used to explicitly represent to which wall or roof a window or door belongs to; there can be only one parent.
+  - **may** have one member with the name `"children"`. The value is an array of integers pointing to other Semantic Objects of the same geometry (index of it, 0-based). This is used to explicitly represent the openings (windows and doors) of walls and roofs.
+  - **may** have other members in the form of a JSON key-value pair, where the value must not be a JSON object (but a string/number/integer/boolean).
 
 ```json
 {
@@ -1313,7 +1313,7 @@ In the following, the Solid has 4 surfaces, and there are 2 themes ("irradiation
 
 ## Geometry Object having texture(s)
 
-To store the texture(s) of a surface, a Geometry Object may have a member with the value `"texture"`, its value is a collection of key-value pairs, where the key is the *theme* of the textures, and the value is one JSON object that must contain one member `"values"`, which is a hierarchy of arrays with integers. For each ring of each surface, the first value refers to the position (0-based) in the `"textures"` member of the `"appearance"` member of the CityJSON object. The other indices refer to the UV positions of the corresponding vertices (as listed in the `"boundaries"` member of the geometry). Each array representing a ring therefore has one more value than that to store its vertices.
+To store the texture(s) of a surface, a Geometry Object may have a member with the name `"texture"`, its value is a collection of key-value pairs, where the key is the *theme* of the textures, and the value is one JSON object that must contain one member `"values"`, which is a hierarchy of arrays with integers. For each ring of each surface, the first value refers to the position (0-based) in the `"textures"` member of the `"appearance"` member of the CityJSON object. The other indices refer to the UV positions of the corresponding vertices (as listed in the `"boundaries"` member of the geometry). Each array representing a ring therefore has one more value than that to store its vertices.
 
 The depth of the array depends on the Geometry object, and is equal to the depth of the `"boundary"` array.
 
@@ -1422,7 +1422,7 @@ A Texture Object:
 
 ## Vertices-texture Object
 
-An Appearance Object may have one member named `"vertices-texture"`. 
+An Appearance Object may have a member with the name `"vertices-texture"`. 
 Its value is an array of the *(u,v)* coordinates of the vertices used for texturing surfaces.
 Their position in this array (0-based) is used by the `"texture"` member of the Geometry Objects.
 


### PR DESCRIPTION
I have mainly focused on typos and consistency issues (eg making sure that we are always using 'member' instead of 'attribute' or 'property' when talking about what is allowed in an object). 

There are also some parts where the meaning might have been altered slightly. For these I will leave specific comments. 