### PR TITLE
Fix nesting level of `semantics` in example JSON.

### DIFF
--- a/specs/specs.bs
+++ b/specs/specs.bs
@@ -661,27 +661,27 @@ That is, the surface representing a road should be split into sub-surfaces (ther
     "lod": "2",
     "boundaries": [
        [[0, 3, 2, 1, 4]], [[4, 5, 6, 9, 12]], [[0, 1, 5]], [[20, 21, 75]]
-    ]
-  }],
-  "semantics": {
-    "surfaces": [
-      {
-        "type": "TrafficArea",
-        "surfaceMaterial": ["asphalt"],
-        "function": "road"
-      },
-      {
-        "type": "AuxiliaryTrafficArea",
-        "function": "green areas"
-      },
-      {
-        "type": "TrafficArea",
-        "surfaceMaterial": ["dirt"],
-        "function": "road"
-      }
     ],
-    "values": [0, 1, null, 2]
-  }
+    "semantics": {
+      "surfaces": [
+        {
+          "type": "TrafficArea",
+          "surfaceMaterial": ["asphalt"],
+          "function": "road"
+        },
+        {
+          "type": "AuxiliaryTrafficArea",
+          "function": "green areas"
+        },
+        {
+          "type": "TrafficArea",
+          "surfaceMaterial": ["dirt"],
+          "function": "road"
+        }
+      ],
+      "values": [0, 1, null, 2]
+    }
+  }]
 }
 ```
 


### PR DESCRIPTION
The example CityJSON shows `semantics` as a field in the city object, but it should be part of the geometry object.