### PR TITLE
Add support for compound CRS as CURIEs

### DIFF
--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -91,8 +91,20 @@
         "maxItems": 6
       },
       "referenceSystem": {
-        "type": "string",
-        "pattern": "^(http|https)://www.opengis.net/def/crs/"
+        "anyOf": [
+          {
+            "type": "string",
+            "pattern": "^(http|https)://www.opengis.net/def/crs/"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^\\[[a-zA-Z]+:[a-zA-Z0-9]+\\]$"
+            },
+            "minItems": 1
+          }
+        ]
       }
     },
     "additionalProperties": false


### PR DESCRIPTION
Allow compound CRS in `metadata.referenceSystem` the form of CURIEs, in addition to the current URI syntax.

For example:

```
"referenceSystem": [
    "[EPSG:4326]",
    "[EPSG:3855]"
  ]
```
The schema allows any UPPER/lowercase letter or digit as identifier, and any UPPER/lowercase letter as authority.

However, this change breaks backwards compatibility, so it would require a new major version.

If we decide to merge this PR, the specs need to be updated too.

Fixes #181 