### PR TITLE
Fix the complete but empty example

### DIFF
--- a/specs/specs.bs
+++ b/specs/specs.bs
@@ -106,7 +106,10 @@ An "empty" but complete CityJSON object will look like this:
   "CityObjects": {},
   "vertices": [],
   "appearance": {},
-  "geometry-templates": {}
+  "geometry-templates": {
+    "templates": [],
+    "vertices-templates": []
+  }
 }
 ```
 


### PR DESCRIPTION
The example of a complete but empty CityJSON object was invalid, because the `templates` and `vertices-templates` members are mandatory if `geometry-templates` is defined. Both members are arrays and they can be empty (but need to be present), just as in case of the root `vertices` member.